### PR TITLE
Better typing of IdDict

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -55,7 +55,8 @@ macro anamnesis(expr::Expr)
 
     esc(quote
         $(MacroTools.combinedef(rawfuncdef))
-        $scrname = Anamnesis.Scribe($rawname)
+        $scrname = Anamnesis.Scribe($rawname,
+                                    IdDict{Any, $(get(origdef, :rtype, :Any))}())
         $(MacroTools.combinedef(funcdef))
     end)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,7 +52,7 @@ end
 @testset "Macros2" begin
     callcount = [0, 0]
     @anamnesis f1(x::AbstractVector{<:Number}) = (callcount[1] += 1; x⋅x - 1)
-    @anamnesis g1(x::Number; y::String) = (callcount[2] += 1; string(x, y))
+    @anamnesis g1(x::Number; y::String)::String = (callcount[2] += 1; string(x, y))
 
     for i ∈ 1:N_CALL_LOOPS
         x = rand(Float64, rand(64:256))
@@ -61,7 +61,7 @@ end
         @test f1(x) == @rawfunc(f1)(x)
         @test f1(x) == @rawfunc(f1)(x)
         @test g1(ξ, y=y) == @rawfunc(g1)(ξ, y=y)
-        @test g1(ξ, y=y) == @rawfunc(g1)(ξ, y=y)
+        @test @inferred g1(ξ, y=y) == @rawfunc(g1)(ξ, y=y)
     end
     @test callcount[1] == 3N_CALL_LOOPS
     @test callcount[2] == 3N_CALL_LOOPS

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Anamnesis
 using Test, Random, LinearAlgebra
 
-srand(999)
+Random.seed!(999)
 
 const NUMBER_TYPES = [Int, UInt, Float64, Complex{Float64}]
 


### PR DESCRIPTION
Another improvement I looked into was making the binding of the scribe `const`, in `macro anamnesis`:
```julia
julia> @anamnesis function moo(x, y)
       x+y
       end

julia> @btime moo(1, 2)
  284.571 ns (1 allocation: 32 bytes)
3
```
whereas without `const`, it's 766 ns. It gives extra warnings ("redefining constant") whenever the definition is updated. But it seems safe enough, since we're invalidating the only code that directly references that variable.