### PR TITLE
Handle optional arguments

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -28,11 +28,10 @@ macro mem(expr::Expr)
 end
 
 
-_striparg(arg::Symbol) = arg
-_striparg(ex::Expr) = (@capture(ex, arg_::dtype_); arg)
+argname(x)::Symbol = splitarg(x)[1]
 
 function _translate_kwarg(ex::Expr)
-    arg = _striparg(ex.args[1])
+    arg = argname(ex)
     Expr(:kw, arg, arg)
 end
 
@@ -50,7 +49,7 @@ macro anamnesis(expr::Expr)
     funcdef = copy(origdef)
     kwargs = _translate_kwarg.(funcdef[:kwargs])
     funcdef[:body] = quote
-        $scrname($(funcdef[:args]...); $(kwargs...))
+        $scrname($(map(argname, funcdef[:args])...); $(kwargs...))
     end
 
     esc(quote

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,7 +51,7 @@ end
 
 @testset "Macros2" begin
     callcount = [0, 0]
-    @anamnesis f1(x::AbstractVector{<:Number}) = (callcount[1] += 1; x⋅x - 1)
+    @anamnesis f1(x::AbstractVector{<:Number}, y=2) = (callcount[1] += 1; x⋅x - y)
     @anamnesis g1(x::Number; y::String) = (callcount[2] += 1; string(x, y))
 
     for i ∈ 1:N_CALL_LOOPS


### PR DESCRIPTION
Fixes issue:

```julia
julia> @anamnesis function blah(x, y=2)
       x+y
       end
blah (generic function with 2 methods)

julia> blah(1, 3)
ERROR: function ##blah__raw does not accept keyword arguments
```